### PR TITLE
Clean the autoload config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,12 @@
         "psr-4": {
             "Joli\\Jane\\Swagger\\Model\\": "generated/Model/",
             "Joli\\Jane\\Swagger\\Normalizer\\": "generated/Normalizer/",
-            "Joli\\Jane\\Swagger\\": "src/",
-            "Joli\\Jane\\Swagger\\Tests\\": "tests/",
-            "Docker\\": "stub/"
+            "Joli\\Jane\\Swagger\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Joli\\Jane\\Swagger\\Tests\\": "tests/"
         }
     },
     "require": {


### PR DESCRIPTION
`Docker` is registered on a non-existent folder, which does not make sense.

And tests don't need to be autoloaded when installing the package as a dependency.
