### PR TITLE
Prevent the same typehint to appear multiple times in the return docblock

### DIFF
--- a/src/Generator/OperationGenerator.php
+++ b/src/Generator/OperationGenerator.php
@@ -87,7 +87,10 @@ class OperationGenerator
             list($outputType, $ifStatus) = $this->createResponseDenormalizationStatement($status, $response->getSchema(), $context);
 
             if (null !== $outputType) {
-                $outputTypes[] = $outputType;
+                if (!in_array($outputType, $outputTypes)) {
+                    $outputTypes[] = $outputType;
+                }
+
                 $outputStatements[] = $ifStatus;
             }
         }

--- a/tests/fixtures/model-in-response/expected/Model/Error.php
+++ b/tests/fixtures/model-in-response/expected/Model/Error.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Model;
+
+class Error
+{
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage($message = null)
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+}

--- a/tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
+++ b/tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Joli\Jane\Reference\Reference;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class ErrorNormalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Error') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Joli\Jane\OpenApi\Tests\Expected\Model\Error) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        if (empty($data)) {
+            return null;
+        }
+        if (isset($data->{'$ref'})) {
+            return new Reference($data->{'$ref'}, $context['rootSchema'] ?: null);
+        }
+        $object = new \Joli\Jane\OpenApi\Tests\Expected\Model\Error();
+        if (!isset($context['rootSchema'])) {
+            $context['rootSchema'] = $object;
+        }
+        if (isset($data->{'message'})) {
+            $object->setMessage($data->{'message'});
+        }
+
+        return $object;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getMessage()) {
+            $data->{'message'} = $object->getMessage();
+        }
+
+        return $data;
+    }
+}

--- a/tests/fixtures/model-in-response/expected/Normalizer/NormalizerFactory.php
+++ b/tests/fixtures/model-in-response/expected/Normalizer/NormalizerFactory.php
@@ -14,6 +14,7 @@ class NormalizerFactory
         $normalizers[] = new NormalizerArray();
         $normalizers[] = new SchemaNormalizer();
         $normalizers[] = new ObjectPropertyNormalizer();
+        $normalizers[] = new ErrorNormalizer();
 
         return $normalizers;
     }

--- a/tests/fixtures/model-in-response/expected/Resource/TestResource.php
+++ b/tests/fixtures/model-in-response/expected/Resource/TestResource.php
@@ -11,7 +11,7 @@ class TestResource extends Resource
      * @param array  $parameters List of parameters
      * @param string $fetch      Fetch mode (object or response)
      *
-     * @return \Psr\Http\Message\ResponseInterface|\Joli\Jane\OpenApi\Tests\Expected\Model\Schema
+     * @return \Psr\Http\Message\ResponseInterface|\Joli\Jane\OpenApi\Tests\Expected\Model\Schema|\Joli\Jane\OpenApi\Tests\Expected\Model\Error
      */
     public function getTest($parameters = [], $fetch = self::FETCH_OBJECT)
     {
@@ -25,6 +25,12 @@ class TestResource extends Resource
         if (self::FETCH_OBJECT == $fetch) {
             if ('200' == $response->getStatusCode()) {
                 return $this->serializer->deserialize($response->getBody()->getContents(), 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Schema', 'json');
+            }
+            if ('400' == $response->getStatusCode()) {
+                return $this->serializer->deserialize($response->getBody()->getContents(), 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json');
+            }
+            if ('404' == $response->getStatusCode()) {
+                return $this->serializer->deserialize($response->getBody()->getContents(), 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json');
             }
         }
 

--- a/tests/fixtures/model-in-response/swagger.json
+++ b/tests/fixtures/model-in-response/swagger.json
@@ -34,6 +34,14 @@
                     "$ref": "#/definitions/Schema"
                 }
             }
+        },
+        "Error": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
         }
     },
     "paths": {
@@ -45,6 +53,18 @@
                         "description": "no error",
                         "schema": {
                             "$ref": "#/definitions/Schema"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
                         }
                     }
                 },


### PR DESCRIPTION
The tests are going to fail because some trailing spaces are commited in. They are removed in 12. Once it gets merged, I can rebase this one.
