### PR TITLE
Support operation without id specified

### DIFF
--- a/src/Generator/GeneratorFactory.php
+++ b/src/Generator/GeneratorFactory.php
@@ -3,6 +3,8 @@
 namespace Joli\Jane\OpenApi\Generator;
 
 use Joli\Jane\Jane;
+use Joli\Jane\OpenApi\Naming\ChainOperationNaming;
+use Joli\Jane\OpenApi\Naming\OperationUrlNaming;
 use Joli\Jane\Reference\Resolver;
 use Joli\Jane\OpenApi\Generator\Parameter\BodyParameterGenerator;
 use Joli\Jane\OpenApi\Generator\Parameter\FormDataParameterGenerator;
@@ -29,7 +31,11 @@ class GeneratorFactory
 
         $operation = new OperationGenerator($resolver, $bodyParameter, $formDataParameter, $headerParameter, $pathParameter, $queryParameter);
         $operationManager = new OperationManager();
-        $client = new ClientGenerator($operationManager, $operation, new OperationIdNaming());
+        $operationNaming = new ChainOperationNaming([
+            new OperationIdNaming(),
+            new OperationUrlNaming(),
+        ]);
+        $client = new ClientGenerator($operationManager, $operation, $operationNaming);
 
         return $client;
     }

--- a/src/Naming/ChainOperationNaming.php
+++ b/src/Naming/ChainOperationNaming.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Naming;
+
+use Joli\Jane\OpenApi\Operation\Operation;
+
+class ChainOperationNaming implements OperationNamingInterface
+{
+    /**
+     * @var OperationNamingInterface[]
+     */
+    private $operationNamings;
+
+    /**
+     * @param OperationNamingInterface[] $operationNamings
+     */
+    public function __construct(array $operationNamings)
+    {
+        $this->operationNamings = $operationNamings;
+    }
+
+    public function generateFunctionName(Operation $operation)
+    {
+        foreach ($this->operationNamings as $operationNaming) {
+            $functionName = $operationNaming->generateFunctionName($operation);
+
+            if (!empty($functionName)) {
+                return $functionName;
+            }
+        }
+
+        return '';
+    }
+}

--- a/src/Naming/OperationUrlNaming.php
+++ b/src/Naming/OperationUrlNaming.php
@@ -11,7 +11,7 @@ class OperationUrlNaming implements OperationNamingInterface
         $prefix = strtolower($operation->getMethod());
 
         $methodName = preg_replace_callback(
-            '/((?P<separator>[^a-zA-Z0-9])+(?P<part>[a-zA-Z0-9]*))/',
+            '/((?P<separator>[^a-zA-Z0-9{}])+(?P<part>[a-zA-Z0-9{}]*))/',
             function($matches) {
                 if ($matches['separator'] === '.') {
                     return '';
@@ -20,6 +20,14 @@ class OperationUrlNaming implements OperationNamingInterface
                 return ucfirst($matches['part']);
             },
             $operation->getPath()
+        );
+
+        $methodName = preg_replace_callback(
+            '/{(?P<parameter>[^{}]+)}/',
+            function($matches) {
+                return 'By' . ucfirst($matches['parameter']);
+            },
+            $methodName
         );
 
         return $prefix . $methodName;

--- a/src/Naming/OperationUrlNaming.php
+++ b/src/Naming/OperationUrlNaming.php
@@ -9,27 +9,19 @@ class OperationUrlNaming implements OperationNamingInterface
     public function generateFunctionName(Operation $operation)
     {
         $prefix = strtolower($operation->getMethod());
-        $parts  = explode('/', $operation->getPath());
-        $parts  = array_filter($parts, function ($part) {
-            $part = trim($part);
 
-            if (empty($part)) {
-                return false;
-            }
+        $methodName = preg_replace_callback(
+            '/((?P<separator>[^a-zA-Z0-9])+(?P<part>[a-zA-Z0-9]*))/',
+            function($matches) {
+                if ($matches['separator'] === '.') {
+                    return '';
+                }
 
-            if (preg_match('/^{(.+?)}$/', $part)) {
-                return false;
-            }
+                return ucfirst($matches['part']);
+            },
+            $operation->getPath()
+        );
 
-            return true;
-        });
-
-        $parts = array_map(function ($part) {
-            $part = trim($part);
-
-            return ucfirst($part);
-        }, $parts);
-
-        return $prefix . implode('', $parts);
+        return $prefix . $methodName;
     }
 }

--- a/tests/fixtures/operations/expected/Model/Thing.php
+++ b/tests/fixtures/operations/expected/Model/Thing.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Model;
+
+class Thing
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName($name = null)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/fixtures/operations/expected/Normalizer/NormalizerFactory.php
+++ b/tests/fixtures/operations/expected/Normalizer/NormalizerFactory.php
@@ -12,6 +12,7 @@ class NormalizerFactory
         $normalizers   = [];
         $normalizers[] = new ReferenceNormalizer();
         $normalizers[] = new NormalizerArray();
+        $normalizers[] = new ThingNormalizer();
 
         return $normalizers;
     }

--- a/tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
+++ b/tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Joli\Jane\Reference\Reference;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class ThingNormalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Thing') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Joli\Jane\OpenApi\Tests\Expected\Model\Thing) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        if (empty($data)) {
+            return null;
+        }
+        if (isset($data->{'$ref'})) {
+            return new Reference($data->{'$ref'}, $context['rootSchema'] ?: null);
+        }
+        $object = new \Joli\Jane\OpenApi\Tests\Expected\Model\Thing();
+        if (!isset($context['rootSchema'])) {
+            $context['rootSchema'] = $object;
+        }
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+
+        return $object;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+
+        return $data;
+    }
+}

--- a/tests/fixtures/operations/expected/Resource/DefaultResource.php
+++ b/tests/fixtures/operations/expected/Resource/DefaultResource.php
@@ -82,4 +82,100 @@ class DefaultResource extends Resource
 
         return $response;
     }
+
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\Joli\Jane\OpenApi\Tests\Expected\Model\Thing[]
+     */
+    public function getThings($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/things';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $response   = $this->httpClient->sendRequest($request);
+        if (self::FETCH_OBJECT == $fetch) {
+            if ('200' == $response->getStatusCode()) {
+                return $this->serializer->deserialize((string) $response->getBody(), 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Thing[]', 'json');
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\Joli\Jane\OpenApi\Tests\Expected\Model\Thing[]
+     */
+    public function getThingsById($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/things/{id}';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $response   = $this->httpClient->sendRequest($request);
+        if (self::FETCH_OBJECT == $fetch) {
+            if ('200' == $response->getStatusCode()) {
+                return $this->serializer->deserialize((string) $response->getBody(), 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Thing[]', 'json');
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\Joli\Jane\OpenApi\Tests\Expected\Model\Thing
+     */
+    public function getAnotherThing($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/another-things';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $response   = $this->httpClient->sendRequest($request);
+        if (self::FETCH_OBJECT == $fetch) {
+            if ('200' == $response->getStatusCode()) {
+                return $this->serializer->deserialize((string) $response->getBody(), 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Thing', 'json');
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\Joli\Jane\OpenApi\Tests\Expected\Model\Thing
+     */
+    public function getAnotherThingById($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/another-things/{id}';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $response   = $this->httpClient->sendRequest($request);
+        if (self::FETCH_OBJECT == $fetch) {
+            if ('200' == $response->getStatusCode()) {
+                return $this->serializer->deserialize((string) $response->getBody(), 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Thing', 'json');
+            }
+        }
+
+        return $response;
+    }
 }

--- a/tests/fixtures/operations/expected/Resource/DefaultResource.php
+++ b/tests/fixtures/operations/expected/Resource/DefaultResource.php
@@ -51,6 +51,25 @@ class DefaultResource extends Resource
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
+    public function getTestOperationUrlById($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/test-operation-url/{id}';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $response   = $this->httpClient->sendRequest($request);
+
+        return $response;
+    }
+
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function getTestOperationUrlWithExtension($parameters = [], $fetch = self::FETCH_OBJECT)
     {
         $queryParam = new QueryParam();

--- a/tests/fixtures/operations/expected/Resource/DefaultResource.php
+++ b/tests/fixtures/operations/expected/Resource/DefaultResource.php
@@ -25,4 +25,42 @@ class DefaultResource extends Resource
 
         return $response;
     }
+
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getTestOperationUrl($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/test-operation-url';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $response   = $this->httpClient->sendRequest($request);
+
+        return $response;
+    }
+
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getTestOperationUrlWithExtension($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/test-operation-url-with-extension.php';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $response   = $this->httpClient->sendRequest($request);
+
+        return $response;
+    }
 }

--- a/tests/fixtures/operations/swagger.json
+++ b/tests/fixtures/operations/swagger.json
@@ -116,6 +116,70 @@
                     "Test"
                 ]
             }
+        },
+        "/things": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "no error",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Thing"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/things/{id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "no error",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Thing"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/another-things": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "no error",
+                        "schema": {
+                            "$ref": "#/definitions/Thing"
+                        }
+                    }
+                }
+            }
+        },
+        "/another-things/{id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "no error",
+                        "schema": {
+                            "$ref": "#/definitions/Thing"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Thing": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/operations/swagger.json
+++ b/tests/fixtures/operations/swagger.json
@@ -11,6 +11,24 @@
                 }
             }
         },
+        "/test-operation-url": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                }
+            }
+        },
+        "/test-operation-url-with-extension.php": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                }
+            }
+        },
         "/test-get": {
             "get": {
                 "operationId": "Get Test",

--- a/tests/fixtures/operations/swagger.json
+++ b/tests/fixtures/operations/swagger.json
@@ -20,6 +20,15 @@
                 }
             }
         },
+        "/test-operation-url/{id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                }
+            }
+        },
         "/test-operation-url-with-extension.php": {
             "get": {
                 "responses": {


### PR DESCRIPTION
Create a ChainOperationNaming to try first the naming from `operationId` if specified, then falback to a combinaison with method + path
