### PR TITLE
Using new PhpCsFixer\Runner\Runner instead of removed PhpCsFixer\Fixer.

### DIFF
--- a/src/JaneOpenApi.php
+++ b/src/JaneOpenApi.php
@@ -23,8 +23,11 @@ use Symfony\Component\Serializer\SerializerInterface;
 use PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Console\ConfigurationResolver;
+use PhpCsFixer\Differ\NullDiffer;
+use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\Finder;
-use PhpCsFixer\Fixer;
+use PhpCsFixer\Linter\NullLinter;
+use PhpCsFixer\Runner\Runner;
 
 class JaneOpenApi
 {
@@ -200,9 +203,9 @@ class JaneOpenApi
         $finder->in($directory);
         $fixerConfig->finder($finder);
 
-        $fixer = new Fixer();
+        $runner = new Runner($fixerConfig, new NullDiffer(), null, new ErrorsManager(), new NullLinter(), false);
 
-        return $fixer->fix($fixerConfig);
+        return $runner->fix();
     }
 
     public static function build()


### PR DESCRIPTION
Because of [PhpCsFixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/)'s [0f7b1acc2b6f5d9ef9543c89a059c6b8bb533999](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/0f7b1acc2b6f5d9ef9543c89a059c6b8bb533999) commit, `PhpCsFixer\Fixer` has been removed and replaced by a set of new interfaces, and it is no longer possible to generate code through jane-openapi.

This PR updates the fixer code using the new `PhpCsFixer\Runner\Runner`.

Please note I also successfully tested [docker-php](https://github.com/docker-php/docker-php)'s code generation.
