### PR TITLE
Adds support for Yaml Schemas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         "nikic/php-parser": "^1.4|^2.0",
         "symfony/options-resolver": "^2.7|^3.0",
         "symfony/console": "^2.3|^3.0",
-        "doctrine/inflector": "^1.0"
+        "doctrine/inflector": "^1.0",
+        "symfony/yaml": "^2.8.2 | ^3.0",
+        "fitbug/symfony-yaml-serializer-encoder-decoder": "^0.1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/Exception/ParseFailureException.php
+++ b/src/Exception/ParseFailureException.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Exception;
+
+use Exception;
+use UnexpectedValueException;
+
+class ParseFailureException extends UnexpectedValueException
+{
+    /**
+     * @var Exception
+     */
+    private $previousYaml;
+
+    /**
+     * Construct the exception.
+     *
+     * @param string    $message      [optional] The Exception message to throw.
+     * @param int       $code         [optional] The Exception code.
+     * @param Exception $previousJson [optional] The previous exception from the Json serialisation attempt
+     * @param Exception $previousYaml [optional] The previous exception from the Yaml serialisation attempt
+     */
+    public function __construct(
+        $message = "",
+        $code = 0,
+        Exception $previousJson = null,
+        Exception $previousYaml = null
+    ) {
+        parent::__construct($message, $code, $previousJson);
+        $this->previousYaml = $previousYaml;
+    }
+
+    /**
+     * Get the previous exception from the Yaml serialisation attempt
+     *
+     * @return Exception
+     */
+    final public function getPreviousYaml()
+    {
+        return $this->previousYaml;
+    }
+
+    /**
+     * Get the previous exception from the Json serialisation attempt
+     *
+     * @return Exception
+     */
+    final public function getPreviousJson()
+    {
+        return $this->getPrevious();
+    }
+}

--- a/src/SchemaParser/SchemaParser.php
+++ b/src/SchemaParser/SchemaParser.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Joli\Jane\OpenApi\SchemaParser;
+
+use Joli\Jane\OpenApi\Exception\ParseFailureException;
+use Joli\Jane\OpenApi\Model\OpenApi;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class SchemaParser
+{
+    const OPEN_API_MODEL    = "Joli\\Jane\\OpenApi\\Model\\OpenApi";
+    const EXCEPTION_MESSAGE = "Could not parse \"%s\", is it a valid specification?";
+    const CONTENT_TYPE_JSON = 'json';
+    const CONTENT_TYPE_YAML = 'yaml';
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * SchemaParser constructor.
+     *
+     * @param SerializerInterface $serializer
+     */
+    public function __construct(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+
+    /**
+     * Parse an file into a OpenAPI Schema model
+     *
+     * @param string $openApiSpec
+     *
+     * @return OpenApi
+     *
+     * @throws ParseFailureException
+     */
+    public function parseSchema($openApiSpec)
+    {
+        $openApiSpecContents = file_get_contents($openApiSpec);
+        $schemaClass         = self::OPEN_API_MODEL;
+        $schema              = null;
+        $jsonException       = null;
+        $yamlException       = null;
+
+        try {
+            $schema = $this->serializer->deserialize(
+                $openApiSpecContents, $schemaClass, self::CONTENT_TYPE_JSON
+            );
+
+        } catch (\Exception $exception) {
+            $jsonException = $exception;
+        }
+
+        if (!$schema) {
+            try {
+                $schema = $this->serializer->deserialize(
+                    $openApiSpecContents, $schemaClass, self::CONTENT_TYPE_YAML
+                );
+            } catch (\Exception $exception) {
+                $yamlException = $exception;
+            }
+
+            if (!$schema) {
+                throw new ParseFailureException(
+                    sprintf(self::EXCEPTION_MESSAGE, $openApiSpec),
+                    1,
+                    $jsonException,
+                    $yamlException
+                );
+            }
+        }
+
+        return $schema;
+    }
+}

--- a/tests/JaneOpenApiResourceTest.php
+++ b/tests/JaneOpenApiResourceTest.php
@@ -26,7 +26,7 @@ class JaneOpenApiResourceTest extends \PHPUnit_Framework_TestCase
         // 2. Generate
         $OpenApi = JaneOpenApi::build();
         $files   = $OpenApi->generate(
-            $testDirectory->getRealPath() . DIRECTORY_SEPARATOR . 'swagger.json',
+            glob($testDirectory->getRealPath() . DIRECTORY_SEPARATOR . 'swagger.*')[0],
             'Joli\Jane\OpenApi\Tests\Expected',
             $testDirectory->getRealPath() . DIRECTORY_SEPARATOR . 'generated'
         );

--- a/tests/fixtures/yaml/expected/Normalizer/NormalizerFactory.php
+++ b/tests/fixtures/yaml/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Joli\Jane\Normalizer\NormalizerArray;
+use Joli\Jane\Normalizer\ReferenceNormalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers   = [];
+        $normalizers[] = new ReferenceNormalizer();
+        $normalizers[] = new NormalizerArray();
+
+        return $normalizers;
+    }
+}

--- a/tests/fixtures/yaml/expected/Resource/TestResource.php
+++ b/tests/fixtures/yaml/expected/Resource/TestResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Resource;
+
+use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Client\Resource;
+
+class TestResource extends Resource
+{
+    /**
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function testReferenceResponse($parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/test-query';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $promise    = $this->httpClient->sendAsyncRequest($request);
+        if (self::FETCH_PROMISE === $fetch) {
+            return $promise;
+        }
+        $response = $promise->wait();
+
+        return $response;
+    }
+}

--- a/tests/fixtures/yaml/swagger.yaml
+++ b/tests/fixtures/yaml/swagger.yaml
@@ -1,0 +1,14 @@
+---
+swagger: '2.0'
+responses:
+  '200':
+    description: no error
+paths:
+  "/test-query":
+    get:
+      operationId: Test Reference Response
+      responses:
+        '200':
+          "$ref": "#/responses/200"
+      tags:
+      - Test


### PR DESCRIPTION
Currently we only support Json Schemas. This is only 1 of the two
standard formats that Swagger supports, the other being YAML. This
change will add support YAML.

Please note that the reason Symfony YAML is locked to ^2.8.2 is due to
versions prior to this treat lines with a "#" in a quoted string
[incorrectly as a comment](https://github.com/symfony/yaml/commit/5f77b9aeb8f7aeda000bc2fea8874f3ccf1ec523). Swagger makes heavy use of "#" symbols
in it's strings to identify references responses and other things,
making it impossible for us to parse the swagger file.

Fixes issue #21
