### PR TITLE
Make the bin script compatible with custom vendor dirs

### DIFF
--- a/bin/jane-openapi
+++ b/bin/jane-openapi
@@ -5,8 +5,8 @@ use Joli\Jane\OpenApi\Application;
 
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once(__DIR__ . '/../vendor/autoload.php');
-} elseif (file_exists(__DIR__ . '/../../../../vendor/autoload.php')) {
-    require_once(__DIR__ . '/../../../../vendor/autoload.php');
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once(__DIR__ . '/../../../autoload.php');
 } else {
     throw new \Exception('Unable to load autoloader');
 }


### PR DESCRIPTION
This is done by avoiding to move up outside the vendor dir and entering it again, as this removes the need to know its name.
