### PR TITLE
Support Snake Cased URL Parameters

### DIFF
--- a/src/Naming/OperationUrlNaming.php
+++ b/src/Naming/OperationUrlNaming.php
@@ -25,7 +25,7 @@ class OperationUrlNaming implements OperationNamingInterface
             }
         }
 
-        preg_match_all('/(?P<separator>[^a-zA-Z0-9{}])+(?P<part>[a-zA-Z0-9{}]*)/', $operation->getPath(), $matches);
+        preg_match_all('/(?P<separator>[^a-zA-Z0-9_{}])+(?P<part>[a-zA-Z0-9_{}]*)/', $operation->getPath(), $matches);
 
         $methodNameParts = [];
         $lastNonParameterPartIndex = 0;
@@ -39,7 +39,13 @@ class OperationUrlNaming implements OperationNamingInterface
 
             if (preg_match_all('/{(?P<parameter>[^{}]+)}/', $part, $parameterMatches)) {
                 foreach($parameterMatches[0] as $parameterIndex => $parameterMatch) {
-                    $methodNameParts[] =  'By' . ucfirst($parameterMatches['parameter'][$parameterIndex]);
+                    $withoutSnakes = preg_replace_callback(
+                        '/(^|_|\.)+(.)/', function ($match) {
+                        return ('.' === $match[1] ? '_' : '') . strtoupper($match[2]);
+                    }, $parameterMatches['parameter'][ $parameterIndex ]
+                    );
+
+                    $methodNameParts[] = 'By' . ucfirst($withoutSnakes);
                 }
             } else {
                 $methodNameParts[] = ucfirst($part);

--- a/tests/fixtures/parameters/expected/Resource/TestResource.php
+++ b/tests/fixtures/parameters/expected/Resource/TestResource.php
@@ -161,4 +161,29 @@ class TestResource extends Resource
 
         return $response;
     }
+
+    /**
+     * @param int    $testInteger
+     * @param array  $parameters  List of parameters
+     * @param string $fetch       Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getByTestInteger($testInteger, $parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/{test_integer}';
+        $url        = str_replace('{test_integer}', urlencode($testInteger), $url);
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $queryParam->buildFormDataString($parameters);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
+        $promise    = $this->httpClient->sendAsyncRequest($request);
+        if (self::FETCH_PROMISE === $fetch) {
+            return $promise;
+        }
+        $response = $promise->wait();
+
+        return $response;
+    }
 }

--- a/tests/fixtures/parameters/swagger.json
+++ b/tests/fixtures/parameters/swagger.json
@@ -179,6 +179,26 @@
                     "Test"
                 ]
             }
+        },
+        "/{test_integer}": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "test_integer",
+                        "in": "path",
+                        "type": "integer",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                },
+                "tags": [
+                    "Test"
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
Currently if you use a snake_cased URL parameter without defining an
operationId in the Swagger file, the name for the function that is
generated will contain curly braces, which is invalid PHP. This fix
resolves that by correctly un-snaking the variable and camel casing it.
