### PR TITLE
Follow PSR2

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,8 @@
+<?php
+
+// Needed to get styleci-bridge loaded
+require_once __DIR__.'/vendor/sllh/php-cs-fixer-styleci-bridge/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+
+return ConfigBridge::create();

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,8 @@
+preset: psr2
+
+finder:
+  exclude:
+    - "tests/fixtures"
+    - "tests/fixtures-boilerplate"
+    - "generated"
+    - "bin"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",
-        "friendsofphp/php-cs-fixer": "v2.0.0-alpha"
+        "friendsofphp/php-cs-fixer": "v2.0.0-alpha",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.1"
     },
     "conflict": {
         "friendsofphp/php-cs-fixer": "<2.0.0-alpha|>2.0.0-alpha"

--- a/src/Generator/GeneratorFactory.php
+++ b/src/Generator/GeneratorFactory.php
@@ -19,7 +19,7 @@ use PhpParser\ParserFactory;
 
 class GeneratorFactory
 {
-    static public function build()
+    public static function build()
     {
         if (class_exists('PhpParser\ParserFactory')) {
             $parserFactory = new ParserFactory();

--- a/src/Generator/InputGeneratorTrait.php
+++ b/src/Generator/InputGeneratorTrait.php
@@ -263,7 +263,8 @@ trait InputGeneratorTrait
 
         $headers = [
             new Expr\ArrayItem(
-                new Scalar\String_($operation->getHost()), new Scalar\String_('Host')
+                new Scalar\String_($operation->getHost()),
+                new Scalar\String_('Host')
             ),
         ];
 
@@ -272,32 +273,33 @@ trait InputGeneratorTrait
         if ($produces && in_array("application/json", $produces)) {
             $headers[]
                 = new Expr\ArrayItem(
-                new Expr\Array_(
-                    [
+                    new Expr\Array_(
+                        [
                         new Expr\ArrayItem(
                             new Scalar\String_("application/json")
                         ),
-                    ]
-                ),
-                new Scalar\String_('Accept')
-            );
+                        ]
+                    ),
+                    new Scalar\String_('Accept')
+                );
         }
 
         $consumes = $operation->getOperation()->getProduces();
 
         if ($operation->getOperation()->getParameters() && $consumes) {
             $bodyParameters = array_filter(
-                $operation->getOperation()->getParameters(), function ($parameter) {
-                return $parameter instanceof BodyParameter;
-            }
+                $operation->getOperation()->getParameters(),
+                function ($parameter) {
+                    return $parameter instanceof BodyParameter;
+                }
             );
 
             if (count($bodyParameters) > 0 && in_array("application/json", $consumes)) {
                 $headers[]
                     = new Expr\ArrayItem(
-                    new Scalar\String_("application/json"),
-                    new Scalar\String_('Content-Type')
-                );
+                        new Scalar\String_("application/json"),
+                        new Scalar\String_('Content-Type')
+                    );
             }
         }
 

--- a/src/Generator/OperationGenerator.php
+++ b/src/Generator/OperationGenerator.php
@@ -60,7 +60,8 @@ class OperationGenerator
             // $request = $this->messageFactory->createRequest('method', $url, $headers, $body);
             new Expr\Assign(new Expr\Variable('request'), new Expr\MethodCall(
                 new Expr\PropertyFetch(new Expr\Variable('this'), 'messageFactory'),
-                'createRequest', [
+                'createRequest',
+                [
                     new Arg(new Scalar\String_($operation->getMethod())),
                     new Arg($urlVariable),
                     new Arg($headerVariable),
@@ -75,7 +76,8 @@ class OperationGenerator
             )),
             // if ($fetch === self::FETCH_PROMISE) { return $promise }
             new Stmt\If_(
-                new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('self::FETCH_PROMISE')), new Expr\Variable('fetch')), [
+                new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('self::FETCH_PROMISE')), new Expr\Variable('fetch')),
+                [
                     'stmts' => [
                         new Stmt\Return_(new Expr\Variable('promise'))
                     ]
@@ -110,7 +112,8 @@ class OperationGenerator
 
         if (!empty($outputStatements)) {
             $statements[] = new Stmt\If_(
-                new Expr\BinaryOp\Equal(new Expr\ConstFetch(new Name('self::FETCH_OBJECT')), new Expr\Variable('fetch')), [
+                new Expr\BinaryOp\Equal(new Expr\ConstFetch(new Name('self::FETCH_OBJECT')), new Expr\Variable('fetch')),
+                [
                     'stmts' => $outputStatements
                 ]
             );
@@ -118,7 +121,8 @@ class OperationGenerator
 
         // return $response
         $statements[] = new Stmt\Return_(new Expr\Variable('response'));
-        $documentation = array_merge([
+        $documentation = array_merge(
+            [
                 '/**',
                 sprintf(" * %s", $operation->getOperation()->getDescription()),
                 ' *',

--- a/src/Generator/OutputGeneratorTrait.php
+++ b/src/Generator/OutputGeneratorTrait.php
@@ -54,7 +54,8 @@ trait OutputGeneratorTrait
             new Expr\BinaryOp\Equal(
                 new Scalar\String_($status),
                 new Expr\MethodCall(new Expr\Variable('response'), 'getStatusCode')
-            ), [
+            ),
+            [
                 'stmts' => [
                     new Stmt\Return_(new Expr\MethodCall(
                         new Expr\PropertyFetch(new Expr\Variable('this'), 'serializer'),

--- a/src/Generator/Parameter/FormDataParameterGenerator.php
+++ b/src/Generator/Parameter/FormDataParameterGenerator.php
@@ -20,5 +20,4 @@ class FormDataParameterGenerator extends NonBodyParameterGenerator
 
         return $statements;
     }
-
 }

--- a/src/JaneOpenApi.php
+++ b/src/JaneOpenApi.php
@@ -90,8 +90,7 @@ class JaneOpenApi
         ClientGenerator $clientGenerator,
         PrettyPrinterAbstract $prettyPrinter,
         ConfigInterface $fixerConfig = null
-    )
-    {
+    ) {
         $this->schemaParser        = $schemaParser;
         $this->clientGenerator     = $clientGenerator;
         $this->prettyPrinter       = $prettyPrinter;

--- a/src/Naming/OperationUrlNaming.php
+++ b/src/Naming/OperationUrlNaming.php
@@ -38,11 +38,13 @@ class OperationUrlNaming implements OperationNamingInterface
             $part = $matches['part'][$index];
 
             if (preg_match_all('/{(?P<parameter>[^{}]+)}/', $part, $parameterMatches)) {
-                foreach($parameterMatches[0] as $parameterIndex => $parameterMatch) {
+                foreach ($parameterMatches[0] as $parameterIndex => $parameterMatch) {
                     $withoutSnakes = preg_replace_callback(
-                        '/(^|_|\.)+(.)/', function ($match) {
-                        return ('.' === $match[1] ? '_' : '') . strtoupper($match[2]);
-                    }, $parameterMatches['parameter'][ $parameterIndex ]
+                        '/(^|_|\.)+(.)/',
+                        function ($match) {
+                            return ('.' === $match[1] ? '_' : '') . strtoupper($match[2]);
+                        },
+                        $parameterMatches['parameter'][ $parameterIndex ]
                     );
 
                     $methodNameParts[] = 'By' . ucfirst($withoutSnakes);

--- a/src/SchemaParser/SchemaParser.php
+++ b/src/SchemaParser/SchemaParser.php
@@ -47,9 +47,10 @@ class SchemaParser
 
         try {
             $schema = $this->serializer->deserialize(
-                $openApiSpecContents, $schemaClass, self::CONTENT_TYPE_JSON
+                $openApiSpecContents,
+                $schemaClass,
+                self::CONTENT_TYPE_JSON
             );
-
         } catch (\Exception $exception) {
             $jsonException = $exception;
         }
@@ -57,7 +58,9 @@ class SchemaParser
         if (!$schema) {
             try {
                 $schema = $this->serializer->deserialize(
-                    $openApiSpecContents, $schemaClass, self::CONTENT_TYPE_YAML
+                    $openApiSpecContents,
+                    $schemaClass,
+                    self::CONTENT_TYPE_YAML
                 );
             } catch (\Exception $exception) {
                 $yamlException = $exception;


### PR DESCRIPTION
This will make the codebase follow PSR2, and ensure that only compilable
PHP is committed. It ignores and warnings about line length but will
fail the build and tests on any other error.

Having a coding standard lowers the barrier to entry for people coming
to use a project, and PSR-2 is the standard which has been adopted most
widely within the PHP community.
