### PR TITLE
Add support for AllOf Inheritance

### DIFF
--- a/src/Guesser/OpenApiSchema/AllOfGuesser.php
+++ b/src/Guesser/OpenApiSchema/AllOfGuesser.php
@@ -3,15 +3,60 @@
 namespace Joli\Jane\OpenApi\Guesser\OpenApiSchema;
 
 use Joli\Jane\Guesser\JsonSchema\AllOfGuesser as BaseAllOfGuesser;
+use Joli\Jane\Guesser\PropertiesGuesserInterface;
 use Joli\Jane\OpenApi\Model\Schema;
+use Joli\Jane\Reference\Resolver;
+use Joli\Jane\Runtime\Reference;
 
-class AllOfGuesser extends BaseAllOfGuesser
+class AllOfGuesser extends BaseAllOfGuesser implements PropertiesGuesserInterface
 {
+    /**
+     * @var Resolver
+     */
+    private $resolver;
+
+    /**
+     * AllOfGuesser constructor.
+     *
+     * @param Resolver $resolver
+     */
+    public function __construct(Resolver $resolver)
+    {
+        $this->resolver = $resolver;
+
+        parent::__construct($resolver);
+    }
+
+
     /**
      * {@inheritDoc}
      */
     public function supportObject($object)
     {
         return (($object instanceof Schema) && is_array($object->getAllOf()) && count($object->getAllOf()) > 0);
+    }
+
+    /**
+     * Return all properties guessed
+     *
+     * @param Schema                                $object
+     * @param string                                $name
+     * @param \Joli\Jane\Guesser\Guess\ClassGuess[] $classes
+     *
+     * @return \Joli\Jane\Guesser\Guess\Property[]
+     */
+    public function guessProperties($object, $name, $classes)
+    {
+        $properties = [];
+
+        foreach ($object->getAllOf() as $allOfSchema) {
+            if ($allOfSchema instanceof Reference) {
+                $allOfSchema = $this->resolver->resolve($allOfSchema);
+            }
+
+            $properties = array_merge($properties, $this->chainGuesser->guessProperties($allOfSchema, $name, $classes));
+        }
+
+        return $properties;
     }
 }

--- a/tests/fixtures/model-in-response/expected/Model/Inherited1.php
+++ b/tests/fixtures/model-in-response/expected/Model/Inherited1.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Model;
+
+class Inherited1
+{
+    /**
+     * @var string
+     */
+    protected $inheritedProperty1;
+
+    /**
+     * @return string
+     */
+    public function getInheritedProperty1()
+    {
+        return $this->inheritedProperty1;
+    }
+
+    /**
+     * @param string $inheritedProperty1
+     *
+     * @return self
+     */
+    public function setInheritedProperty1($inheritedProperty1 = null)
+    {
+        $this->inheritedProperty1 = $inheritedProperty1;
+
+        return $this;
+    }
+}

--- a/tests/fixtures/model-in-response/expected/Model/Schema.php
+++ b/tests/fixtures/model-in-response/expected/Model/Schema.php
@@ -32,6 +32,14 @@ class Schema
      * @var Schema
      */
     protected $objectRefProperty;
+    /**
+     * @var string
+     */
+    protected $inheritedProperty1;
+    /**
+     * @var string
+     */
+    protected $inheritedProperty2;
 
     /**
      * @return string
@@ -169,6 +177,46 @@ class Schema
     public function setObjectRefProperty(Schema $objectRefProperty = null)
     {
         $this->objectRefProperty = $objectRefProperty;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInheritedProperty1()
+    {
+        return $this->inheritedProperty1;
+    }
+
+    /**
+     * @param string $inheritedProperty1
+     *
+     * @return self
+     */
+    public function setInheritedProperty1($inheritedProperty1 = null)
+    {
+        $this->inheritedProperty1 = $inheritedProperty1;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInheritedProperty2()
+    {
+        return $this->inheritedProperty2;
+    }
+
+    /**
+     * @param string $inheritedProperty2
+     *
+     * @return self
+     */
+    public function setInheritedProperty2($inheritedProperty2 = null)
+    {
+        $this->inheritedProperty2 = $inheritedProperty2;
 
         return $this;
     }

--- a/tests/fixtures/model-in-response/expected/Normalizer/Inherited1Normalizer.php
+++ b/tests/fixtures/model-in-response/expected/Normalizer/Inherited1Normalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class Inherited1Normalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Inherited1') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Joli\Jane\OpenApi\Tests\Expected\Model\Inherited1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $object = new \Joli\Jane\OpenApi\Tests\Expected\Model\Inherited1();
+        if (property_exists($data, 'inheritedProperty1')) {
+            $object->setInheritedProperty1($data->{'inheritedProperty1'});
+        }
+
+        return $object;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getInheritedProperty1()) {
+            $data->{'inheritedProperty1'} = $object->getInheritedProperty1();
+        }
+
+        return $data;
+    }
+}

--- a/tests/fixtures/model-in-response/expected/Normalizer/NormalizerFactory.php
+++ b/tests/fixtures/model-in-response/expected/Normalizer/NormalizerFactory.php
@@ -10,6 +10,7 @@ class NormalizerFactory
         $normalizers[] = new \Joli\Jane\Runtime\Normalizer\ArrayDenormalizer();
         $normalizers[] = new SchemaNormalizer();
         $normalizers[] = new ObjectPropertyNormalizer();
+        $normalizers[] = new Inherited1Normalizer();
         $normalizers[] = new ErrorNormalizer();
 
         return $normalizers;

--- a/tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
+++ b/tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
@@ -58,6 +58,12 @@ class SchemaNormalizer extends SerializerAwareNormalizer implements Denormalizer
         if (property_exists($data, 'objectRefProperty')) {
             $object->setObjectRefProperty($this->serializer->deserialize($data->{'objectRefProperty'}, 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\Schema', 'raw', $context));
         }
+        if (property_exists($data, 'inheritedProperty1')) {
+            $object->setInheritedProperty1($data->{'inheritedProperty1'});
+        }
+        if (property_exists($data, 'inheritedProperty2')) {
+            $object->setInheritedProperty2($data->{'inheritedProperty2'});
+        }
 
         return $object;
     }
@@ -93,6 +99,12 @@ class SchemaNormalizer extends SerializerAwareNormalizer implements Denormalizer
         }
         if (null !== $object->getObjectRefProperty()) {
             $data->{'objectRefProperty'} = $this->serializer->serialize($object->getObjectRefProperty(), 'raw', $context);
+        }
+        if (null !== $object->getInheritedProperty1()) {
+            $data->{'inheritedProperty1'} = $object->getInheritedProperty1();
+        }
+        if (null !== $object->getInheritedProperty2()) {
+            $data->{'inheritedProperty2'} = $object->getInheritedProperty2();
         }
 
         return $data;

--- a/tests/fixtures/model-in-response/swagger.json
+++ b/tests/fixtures/model-in-response/swagger.json
@@ -3,6 +3,19 @@
     "definitions": {
         "Schema": {
             "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Inherited1"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "inheritedProperty2": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
             "properties": {
                 "stringProperty": {
                     "type": "string"
@@ -32,6 +45,14 @@
                 },
                 "objectRefProperty": {
                     "$ref": "#/definitions/Schema"
+                }
+            }
+        },
+        "Inherited1": {
+            "type": "object",
+            "properties": {
+                "inheritedProperty1": {
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
Resolves janephp/openapi#32, janephp/openapi#33.

The properties of the model will be include the properties of the object
that have been included in the AllOf property in the schema. It supports
both references and real definitions.
