### PR TITLE
Add support for BodyParameter with schema type "object"

### DIFF
--- a/src/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -73,7 +73,7 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
         }
 
         $classes = [];
-        $classes = array_merge($classes, $this->getClassFromParameters($name, $operation->getParameters()));
+        $classes = array_merge($classes, $this->getClassFromParameters($name, $operation->getParameters(), $operation));
 
         foreach ($operation->getResponses() as $response) {
             if ($response instanceof Response) {
@@ -89,10 +89,11 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
      *
      * @param $name
      * @param $parameters
+     * @param $operation
      *
      * @return array
      */
-    protected function getClassFromParameters($name, $parameters)
+    protected function getClassFromParameters($name, $parameters, $operation = null)
     {
         if ($parameters === null) {
             return [];
@@ -102,7 +103,11 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
 
         foreach ($parameters as $parameterName => $parameter) {
             if ($parameter instanceof BodyParameter) {
-                $classes = array_merge($classes, $this->chainGuesser->guessClass($parameter->getSchema(), $parameterName));
+                if (!is_numeric($parameterName)) {
+                    $classes = array_merge($classes, $this->chainGuesser->guessClass($parameter->getSchema(), $parameterName));
+                } else if ($operation !== null) {
+                    $classes = array_merge($classes, $this->chainGuesser->guessClass($parameter->getSchema(), $operation->getOperationId() . 'Body'));
+                }
             }
         }
 

--- a/tests/fixtures/body-parameter/expected/Model/TestBodyParameterWithObjectSchemaTypeBody.php
+++ b/tests/fixtures/body-parameter/expected/Model/TestBodyParameterWithObjectSchemaTypeBody.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Model;
+
+class TestBodyParameterWithObjectSchemaTypeBody
+{
+    /**
+     * @var string
+     */
+    protected $exampleProperty;
+
+    /**
+     * @return string
+     */
+    public function getExampleProperty()
+    {
+        return $this->exampleProperty;
+    }
+
+    /**
+     * @param string $exampleProperty
+     *
+     * @return self
+     */
+    public function setExampleProperty($exampleProperty = null)
+    {
+        $this->exampleProperty = $exampleProperty;
+
+        return $this;
+    }
+}

--- a/tests/fixtures/body-parameter/expected/Normalizer/NormalizerFactory.php
+++ b/tests/fixtures/body-parameter/expected/Normalizer/NormalizerFactory.php
@@ -10,6 +10,7 @@ class NormalizerFactory
         $normalizers[] = new \Joli\Jane\Runtime\Normalizer\ArrayDenormalizer();
         $normalizers[] = new SchemaNormalizer();
         $normalizers[] = new ObjectPropertyNormalizer();
+        $normalizers[] = new TestBodyParameterWithObjectSchemaTypeBodyNormalizer();
 
         return $normalizers;
     }

--- a/tests/fixtures/body-parameter/expected/Normalizer/TestBodyParameterWithObjectSchemaTypeBodyNormalizer.php
+++ b/tests/fixtures/body-parameter/expected/Normalizer/TestBodyParameterWithObjectSchemaTypeBodyNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Joli\Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class TestBodyParameterWithObjectSchemaTypeBodyNormalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Joli\\Jane\\OpenApi\\Tests\\Expected\\Model\\TestBodyParameterWithObjectSchemaTypeBody') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Joli\Jane\OpenApi\Tests\Expected\Model\TestBodyParameterWithObjectSchemaTypeBody) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $object = new \Joli\Jane\OpenApi\Tests\Expected\Model\TestBodyParameterWithObjectSchemaTypeBody();
+        if (property_exists($data, 'exampleProperty')) {
+            $object->setExampleProperty($data->{'exampleProperty'});
+        }
+
+        return $object;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getExampleProperty()) {
+            $data->{'exampleProperty'} = $object->getExampleProperty();
+        }
+
+        return $data;
+    }
+}

--- a/tests/fixtures/body-parameter/expected/Resource/TestResource.php
+++ b/tests/fixtures/body-parameter/expected/Resource/TestResource.php
@@ -78,4 +78,28 @@ class TestResource extends Resource
 
         return $response;
     }
+
+    /**
+     * @param object $testObjectSchemaType
+     * @param array  $parameters           List of parameters
+     * @param string $fetch                Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function testBodyParameterWithObjectSchemaType($testObjectSchemaType, $parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url        = '/test-object-schema-type-object';
+        $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body       = $testObjectSchemaType;
+        $request    = $this->messageFactory->createRequest('POST', $url, $headers, $body);
+        $promise    = $this->httpClient->sendAsyncRequest($request);
+        if (self::FETCH_PROMISE === $fetch) {
+            return $promise;
+        }
+        $response = $promise->wait();
+
+        return $response;
+    }
 }

--- a/tests/fixtures/body-parameter/swagger.json
+++ b/tests/fixtures/body-parameter/swagger.json
@@ -112,6 +112,34 @@
                     "Test"
                 ]
             }
+        },
+        "/test-object-schema-type-object": {
+            "post": {
+                "operationId": "Test Body Parameter With Object Schema Type",
+                "parameters": [
+                    {
+                        "name": "testObjectSchemaType",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "exampleProperty": {
+                                    "type" : "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                },
+                "tags": [
+                    "Test"
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
Magento 2 swagger schema contains instances of the following:

```json
"/V1/customers": {
    "post": {
        "tags": ["customerAccountManagementV1"],
        "description": "Create customer account. Perform necessary business operations like sending email.",
        "operationId": "customerAccountManagementV1CreateAccountPost",
        "parameters": [{
            "name": "$body",
            "in": "body",
            "schema": {
                "required": ["customer"],
                "properties": {
                    "customer": {
                        "$ref": "#/definitions/customer-data-customer-interface"
                    },
                    "password": {
                        "type": "string"
                    },
                    "redirectUrl": {
                        "type": "string"
                    }
                },
                "type": "object"
            }
        }],
 ...
        }
    }
}
```
(see http://devdocs.magento.com/swagger/schemas/latest-2.1.schema.json for example)

Where the body parameter has a schema with type "object". This passes validation when run against the Open API schema. 

When generating a client for Magento 2, I was getting classes generated as follows:

```php
class 0
{
    /**
     * @var string
     */
    protected $username;
    /**
```

```php
class 1
{
    /**
     * @var string
     */
    protected $email;
```

This was a problem, not only because of the numerical classnames, but also because there were multiple BodyParameters being assigned the classname of `0`, `1`, `2` etc. 

This fix uses a combination of `operationId` (which is unique) + `Body` to generate a unique classname. Unsure if this is the correct fix but it seems to work for me. 
