### PR TITLE
Prevent doubleslashes with basepath in operations

### DIFF
--- a/src/Operation/Operation.php
+++ b/src/Operation/Operation.php
@@ -32,7 +32,7 @@ class Operation
     public function __construct(OpenApiOperation $operation, $path, $method, $basePath = "", $host = 'localhost')
     {
         $this->operation = $operation;
-        $this->path      = $basePath . $path;
+        $this->path      = preg_replace('#^/+#', '/', $basePath . $path);
         $this->method    = $method;
         $this->host      = $host;
     }

--- a/tests/fixtures/operations/swagger.json
+++ b/tests/fixtures/operations/swagger.json
@@ -1,5 +1,6 @@
 {
     "swagger": "2.0",
+    "basePath": "/",
     "paths": {
         "/test-no-tag": {
             "get": {


### PR DESCRIPTION
Hi,

When you generate an API with a [basePath](http://swagger.io/specification/#pathTemplating), it creates url with double slashes.

Exemple:

```json
{
    "swagger": "2.0",
    "info": {
        "title": "My API",
        "version": "1.0.0"
    },
    "host": "dev.local",
    "basePath": "/",
    "schemes": [
        "https"
    ],
    "produces": [
        "application/json"
    ],
    "paths": {
        "/orm/country": {
            "get": 
...
```

It generates ressource:

```php
    public function getCountries($parameters = array(), $fetch = self::FETCH_OBJECT)
    {
        $queryParam = new QueryParam();
        $url = '//orm/country';
```

And when running code: 

```
GuzzleHttp\Exception\ConnectException: cURL error 6: Could not resolve host: orm (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)
```

My PR prevents double slashes (unit tests updated too).