### PR TITLE
Update nikic/php-parser from ^2.0 to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "jane/jane": "dev-master",
         "jane/runtime": "dev-master as 1.1",
         "jane/openapi-runtime": "^1.0",
-        "nikic/php-parser": "^1.4|^2.0",
+        "nikic/php-parser": "^1.4|^2.0|^3.0",
         "symfony/console": "^2.3|^3.0",
         "doctrine/inflector": "^1.0",
         "symfony/yaml": "^2.8.2 | ^3.0",


### PR DESCRIPTION
Waiting for jane/jane to merge the [pull request](https://github.com/janephp/jane/pull/42), and the repo can update to nikic/php-parse ^3.0