### PR TITLE
Fixed support for php-cs-fixer 2.9.0.

### DIFF
--- a/src/JaneOpenApi.php
+++ b/src/JaneOpenApi.php
@@ -27,6 +27,7 @@ use PhpCsFixer\Differ\NullDiffer;
 use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\Finder;
 use PhpCsFixer\Runner\Runner;
+use PhpCsFixer\ToolInfo;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PhpParser\PrettyPrinterAbstract;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
@@ -228,7 +229,7 @@ EOH
                 );
         }
         $resolverOptions = array('allow-risky' => true);
-        $resolver = new ConfigurationResolver($fixerConfig, $resolverOptions, $directory);
+        $resolver = new ConfigurationResolver($fixerConfig, $resolverOptions, $directory, new ToolInfo());
 
         $finder = new Finder();
         $finder->in($directory);

--- a/tests/fixtures/body-parameter/expected/Model/Schema.php
+++ b/tests/fixtures/body-parameter/expected/Model/Schema.php
@@ -196,7 +196,7 @@ class Schema
      *
      * @return self
      */
-    public function setObjectRefProperty(Schema $objectRefProperty = null)
+    public function setObjectRefProperty(self $objectRefProperty = null)
     {
         $this->objectRefProperty = $objectRefProperty;
 

--- a/tests/fixtures/content-type/expected/Model/Schema.php
+++ b/tests/fixtures/content-type/expected/Model/Schema.php
@@ -196,7 +196,7 @@ class Schema
      *
      * @return self
      */
-    public function setObjectRefProperty(Schema $objectRefProperty = null)
+    public function setObjectRefProperty(self $objectRefProperty = null)
     {
         $this->objectRefProperty = $objectRefProperty;
 

--- a/tests/fixtures/model-in-response/expected/Model/Schema.php
+++ b/tests/fixtures/model-in-response/expected/Model/Schema.php
@@ -172,7 +172,7 @@ class Schema
      *
      * @return self
      */
-    public function setObjectRefProperty(Schema $objectRefProperty = null)
+    public function setObjectRefProperty(self $objectRefProperty = null)
     {
         $this->objectRefProperty = $objectRefProperty;
 


### PR DESCRIPTION
Fixes issue #71 
Have tested with versions 2.8.4 and 2.9.0 of php-cs-fixer.
Updated the tests to pass, it seems current code generation libraries use `self` as a type hint when applicable.